### PR TITLE
feat: 게임 기록 페이지 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,7 @@ export const metadata: Metadata = {
   keywords: [
     "나르지지",
     "nar.gg",
+    "nar.kr",
     "롤",
     "리그오브레전드",
     "프로경기",

--- a/app/pro-matches/[gameId]/record/page.tsx
+++ b/app/pro-matches/[gameId]/record/page.tsx
@@ -1,0 +1,12 @@
+import { GameRecordPage } from "@/pages/game-record/ui/game-record-page";
+
+interface PageProps {
+  params: Promise<{
+    gameId: string;
+  }>;
+}
+
+export default async function Page({ params }: PageProps) {
+  const { gameId } = await params;
+  return <GameRecordPage gameId={gameId} />;
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mantine/charts": "^8.3.10",
     "@mantine/core": "^8.3.10",
     "@mantine/hooks": "^8.3.10",
     "@tabler/icons-react": "^3.36.0",
@@ -20,7 +21,8 @@
     "dayjs": "^1.11.19",
     "next": "16.1.0",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "recharts": "^3.6.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)
+      '@mantine/charts':
+        specifier: ^8.3.10
+        version: 8.3.10(@mantine/core@8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mantine/hooks@8.3.10(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))
       '@mantine/core':
         specifier: ^8.3.10
         version: 8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -44,6 +47,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      recharts:
+        specifier: ^3.6.0
+        version: 3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -438,6 +444,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mantine/charts@8.3.10':
+    resolution: {integrity: sha512-/JbuxY7qzrxrZR7ZjKj9dD8OXq03nAIClqJ+fD5ezF8J1cVYH9nx0IaIu8RPpaT4UwRdxz+TH/EutQ0LdeOz8w==}
+    peerDependencies:
+      '@mantine/core': 8.3.10
+      '@mantine/hooks': 8.3.10
+      react: ^18.x || ^19.x
+      react-dom: ^18.x || ^19.x
+      recharts: '>=2.13.3'
+
   '@mantine/core@8.3.10':
     resolution: {integrity: sha512-aKQFETN14v6GtM07b/G5yJneMM1yrgf9mNrTah6GVy5DvQM0AeutITT7toHqh5gxxwzdg/DoY+HQsv5zhqnc5g==}
     peerDependencies:
@@ -523,8 +538,25 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -645,6 +677,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -667,6 +726,9 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.50.0':
     resolution: {integrity: sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==}
@@ -990,6 +1052,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1024,6 +1130,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1099,6 +1208,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.43.0:
+    resolution: {integrity: sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1223,6 +1335,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1396,6 +1511,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.0:
+    resolution: {integrity: sha512-dlzb07f5LDY+tzs+iLCSXV2yuhaYfezqyZQc+n6baLECWkOMEWxkECAOnXL0ba7lsA25fM9b2jtzpu/uxo1a7g==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1407,6 +1528,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1864,6 +1989,18 @@ packages:
       react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -1904,6 +2041,22 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.6.0:
+    resolution: {integrity: sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -1911,6 +2064,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2079,6 +2235,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2200,6 +2359,14 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2649,6 +2816,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mantine/charts@8.3.10(@mantine/core@8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mantine/hooks@8.3.10(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1))':
+    dependencies:
+      '@mantine/core': 8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mantine/hooks': 8.3.10(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      recharts: 3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
+
   '@mantine/core@8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@floating-ui/react': 0.27.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2718,7 +2893,23 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.0
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2820,6 +3011,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2839,6 +3054,8 @@ snapshots:
   '@types/react@19.2.7':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -3193,6 +3410,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -3222,6 +3477,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -3366,6 +3623,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.43.0: {}
 
   escalade@3.2.0: {}
 
@@ -3574,6 +3833,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3736,6 +3997,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.0: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3748,6 +4013,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4180,6 +4447,15 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
+  react-redux@9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -4218,6 +4494,32 @@ snapshots:
 
   react@19.2.3: {}
 
+  recharts@3.6.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.43.0
+      eventemitter3: 5.0.1
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@19.2.7)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -4237,6 +4539,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -4459,6 +4763,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -4609,6 +4915,27 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.7
+
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/pages/game-record/model/use-game-data-processor.ts
+++ b/src/pages/game-record/model/use-game-data-processor.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import { useMemo } from "react";
+import type {
+  GameDetailData,
+  GameDetailPlayer,
+} from "@/entities/games/model/games.dto";
+
+interface TeamStats {
+  kills: number;
+  deaths: number;
+  assists: number;
+  totalGold: number;
+  totalDamage: number;
+  visionScore: number;
+  dragons: number;
+  barons: number;
+  heralds: number;
+  towers: number;
+  inhibitors: number;
+  voidGrubs: number;
+  elders: number;
+  infernals: number;
+  mountains: number;
+  clouds: number;
+  oceans: number;
+  chemtechs: number;
+  hextechs: number;
+  turretPlates: number;
+  firstDragon: boolean;
+  firstBaron: boolean;
+  firstHerald: boolean;
+  firstTower: boolean;
+}
+
+interface ProcessedTeam {
+  name: string;
+  result: number;
+  players: GameDetailPlayer[];
+  bans: string[];
+  stats: TeamStats;
+}
+
+interface GameInfo {
+  league: string;
+  split: string;
+  playoffs: number;
+  date: string;
+  game: number;
+  patch: string;
+  gamelength: number;
+}
+
+const getChampionImageUrl = (championName: string): string => {
+  const nameMap: Record<string, string> = {
+    Wukong: "MonkeyKing",
+    Drmundo: "DrMundo",
+    Jarvaniv: "JarvanIV",
+    Kogmaw: "KogMaw",
+    Leesin: "LeeSin",
+    Masteryi: "MasterYi",
+    Missfortune: "MissFortune",
+    Monkeyking: "MonkeyKing",
+    Twistedfate: "TwistedFate",
+    Xinzhao: "XinZhao",
+    Aurelionsol: "AurelionSol",
+    Reksai: "RekSai",
+    Tahmkench: "TahmKench",
+    Ksante: "KSante",
+  };
+  const finalName = nameMap[championName] || championName;
+  return `https://ddragon.leagueoflegends.com/cdn/15.13.1/img/champion/${finalName}.png`;
+};
+
+export function useGameDataProcessor(gameData: GameDetailData | null | undefined) {
+  return useMemo(() => {
+    if (!gameData) {
+      return {
+        gameInfo: null,
+        blueTeam: null,
+        redTeam: null,
+        getChampionImageUrl,
+      };
+    }
+
+    const gameInfo: GameInfo = {
+      league: gameData.league,
+      split: gameData.split,
+      playoffs: gameData.playoffs,
+      date: gameData.date,
+      game: gameData.game,
+      patch: gameData.patch,
+      gamelength: gameData.gamelength,
+    };
+
+    const bluePlayers = gameData.players.filter(
+      (p) => p.side.toLowerCase() === "blue"
+    );
+    const redPlayers = gameData.players.filter(
+      (p) => p.side.toLowerCase() === "red"
+    );
+
+    const calculateTeamStats = (players: GameDetailPlayer[]): TeamStats => {
+      const firstPlayer = players[0];
+      return {
+        kills: players.reduce((sum, p) => sum + p.kills, 0),
+        deaths: players.reduce((sum, p) => sum + p.deaths, 0),
+        assists: players.reduce((sum, p) => sum + p.assists, 0),
+        totalGold: players.reduce((sum, p) => sum + p.totalGold, 0),
+        totalDamage: players.reduce((sum, p) => sum + p.damageToChampions, 0),
+        visionScore: players.reduce((sum, p) => sum + p.visionScore, 0),
+        dragons: firstPlayer?.dragons || 0,
+        barons: firstPlayer?.barons || 0,
+        heralds: firstPlayer?.heralds || 0,
+        towers: firstPlayer?.towers || 0,
+        inhibitors: firstPlayer?.inhibitors || 0,
+        voidGrubs: firstPlayer?.voidGrubs || 0,
+        elders: firstPlayer?.elders || 0,
+        infernals: firstPlayer?.infernals || 0,
+        mountains: firstPlayer?.mountains || 0,
+        clouds: firstPlayer?.clouds || 0,
+        oceans: firstPlayer?.oceans || 0,
+        chemtechs: firstPlayer?.chemtechs || 0,
+        hextechs: firstPlayer?.hextechs || 0,
+        turretPlates: firstPlayer?.turretPlates || 0,
+        firstDragon: firstPlayer?.firstdragon || false,
+        firstBaron: firstPlayer?.firstbaron || false,
+        firstHerald: firstPlayer?.firstherald || false,
+        firstTower: firstPlayer?.firsttower || false,
+      };
+    };
+
+    const blueTeam: ProcessedTeam = {
+      name: bluePlayers[0]?.teamname || "Blue Team",
+      result: bluePlayers[0]?.result || 0,
+      players: bluePlayers,
+      bans: gameData.bans?.blue || [],
+      stats: calculateTeamStats(bluePlayers),
+    };
+
+    const redTeam: ProcessedTeam = {
+      name: redPlayers[0]?.teamname || "Red Team",
+      result: redPlayers[0]?.result || 0,
+      players: redPlayers,
+      bans: gameData.bans?.red || [],
+      stats: calculateTeamStats(redPlayers),
+    };
+
+    return {
+      gameInfo,
+      blueTeam,
+      redTeam,
+      getChampionImageUrl,
+    };
+  }, [gameData]);
+}

--- a/src/pages/game-record/ui/game-header.tsx
+++ b/src/pages/game-record/ui/game-header.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import {
+  Paper,
+  Stack,
+  Group,
+  Text,
+  Divider,
+  Flex,
+  Avatar,
+  Center,
+  Box,
+} from "@mantine/core";
+import type { GameDetailPlayer } from "@/entities/games/model/games.dto";
+
+interface TeamData {
+  name: string;
+  result: number;
+  players: GameDetailPlayer[];
+  bans: string[];
+}
+
+interface GameInfo {
+  league: string;
+  split: string;
+  playoffs: number;
+  date: string;
+  game: number;
+  patch: string;
+  gamelength: number;
+}
+
+interface GameHeaderProps {
+  gameInfo: GameInfo;
+  blueTeam: TeamData;
+  redTeam: TeamData;
+  getChampionImageUrl: (name: string) => string;
+}
+
+const formatTime = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+};
+
+export function GameHeader({
+  gameInfo,
+  blueTeam,
+  redTeam,
+  getChampionImageUrl,
+}: GameHeaderProps) {
+  const BannedChampion = ({
+    championName,
+    size = 32,
+  }: {
+    championName: string;
+    size?: number;
+  }) => (
+    <Box style={{ position: "relative" }}>
+      <Avatar src={getChampionImageUrl(championName)} size={size} radius="sm" />
+      <Box
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          width: `calc(${size}px * 0.8)`,
+          height: "2px",
+          backgroundColor: "rgba(255, 255, 255, 0.9)",
+          transform: "translate(-50%, -50%) rotate(45deg)",
+          borderRadius: "2px",
+          boxShadow: "0 0 2px black",
+        }}
+      />
+    </Box>
+  );
+
+  const renderTeamDisplay = (team: TeamData, color: "blue" | "red") => (
+    <Stack align="center" gap="lg" style={{ flex: 1, minWidth: 0 }}>
+      <Group>
+        <Text size="2rem" fw={800} c={`${color}.7`}>
+          {team.name}
+        </Text>
+        {team.result === 1 && (
+          <Text size="xl" fw={700} c="dark">
+            (승)
+          </Text>
+        )}
+      </Group>
+      <Flex gap="md" justify="center">
+        {team.players.map((player) => (
+          <Stack key={player.participantid} align="center" gap="xs">
+            <Avatar
+              src={getChampionImageUrl(player.champion)}
+              size={64}
+              radius="md"
+              style={{ border: `2px solid var(--mantine-color-${color}-6)` }}
+            />
+            <Text
+              size="xs"
+              ta="center"
+              c="gray.7"
+              fw={500}
+              w={64}
+              truncate="end"
+            >
+              {player.playername}
+            </Text>
+          </Stack>
+        ))}
+      </Flex>
+      <Group justify="center" gap="xs" mt="sm">
+        {team.bans.map((champion, idx) => (
+          <BannedChampion key={idx} championName={champion} size={36} />
+        ))}
+      </Group>
+    </Stack>
+  );
+
+  const renderMobileTeamDisplay = (team: TeamData, color: "blue" | "red") => (
+    <Stack align="center" gap="md">
+      <Group gap="sm">
+        <Text size="xl" fw={800} c={`${color}.7`}>
+          {team.name}
+        </Text>
+        {team.result === 1 && (
+          <Text size="lg" fw={700} c="dark">
+            (승)
+          </Text>
+        )}
+      </Group>
+      <Flex gap="xs" justify="center">
+        {team.players.map((player) => (
+          <Stack key={player.participantid} align="center" gap={2}>
+            <Avatar
+              src={getChampionImageUrl(player.champion)}
+              size={44}
+              radius="sm"
+              style={{ border: `2px solid var(--mantine-color-${color}-6)` }}
+            />
+            <Text
+              size="10px"
+              ta="center"
+              c="gray.7"
+              fw={500}
+              w={44}
+              truncate="end"
+            >
+              {player.playername}
+            </Text>
+          </Stack>
+        ))}
+      </Flex>
+      <Group justify="center" gap={4} mt="xs">
+        {team.bans.map((champion, idx) => (
+          <BannedChampion key={idx} championName={champion} size={28} />
+        ))}
+      </Group>
+    </Stack>
+  );
+
+  return (
+    <Paper p={{ base: "md", md: "xl" }} withBorder radius="md">
+      <Stack>
+        <Group justify="space-between" wrap="wrap" gap="xs">
+          <Group>
+            <Text size="lg" fw={700}>
+              {gameInfo.league}
+            </Text>
+            <Text c="dimmed" size="sm">
+              {gameInfo.split} {gameInfo.playoffs ? "Playoffs" : ""}
+            </Text>
+          </Group>
+          <Group c="dimmed" gap="md" fz="xs">
+            <Text size="sm">{gameInfo.date}</Text>
+            <Text size="sm">Game {gameInfo.game}</Text>
+            <Text size="sm">Patch {gameInfo.patch}</Text>
+            <Text size="sm">{formatTime(gameInfo.gamelength)}</Text>
+          </Group>
+        </Group>
+        <Divider />
+
+        {/* Desktop View */}
+        <Group justify="center" gap={0} visibleFrom="sm" mt="md">
+          {renderTeamDisplay(blueTeam, "blue")}
+          <Center px={50}>
+            <Text size="2rem" fw={700} c="gray.5">
+              VS
+            </Text>
+          </Center>
+          {renderTeamDisplay(redTeam, "red")}
+        </Group>
+
+        {/* Mobile View */}
+        <Stack gap="xl" hiddenFrom="sm" mt="md">
+          {renderMobileTeamDisplay(blueTeam, "blue")}
+          <Center>
+            <Text size="xl" fw={700} c="gray.5">
+              VS
+            </Text>
+          </Center>
+          {renderMobileTeamDisplay(redTeam, "red")}
+        </Stack>
+      </Stack>
+    </Paper>
+  );
+}

--- a/src/pages/game-record/ui/game-record-page.tsx
+++ b/src/pages/game-record/ui/game-record-page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Container,
+  Stack,
+  Tabs,
+  ScrollArea,
+  Loader,
+  Center,
+  Text,
+} from "@mantine/core";
+import { useQuery } from "@tanstack/react-query";
+import { gamesQueries } from "@/entities/games/model/games.queries";
+import { useGameDataProcessor } from "../model/use-game-data-processor";
+import { GameHeader } from "./game-header";
+import { OverviewTab } from "./overview-tab";
+import { PlayersTab } from "./players-tab";
+import { ObjectivesTab } from "./objectives-tab";
+import { TimelineAnalysisTab } from "./timeline-analysis-tab";
+
+interface GameRecordPageProps {
+  gameId: string;
+}
+
+export function GameRecordPage({ gameId }: GameRecordPageProps) {
+  const [activeTab, setActiveTab] = useState<string | null>("overview");
+
+  const {
+    data: gameData,
+    isLoading,
+    isError,
+    error,
+  } = useQuery(gamesQueries.detail(gameId));
+
+  const { gameInfo, blueTeam, redTeam, getChampionImageUrl } =
+    useGameDataProcessor(gameData);
+
+  if (isLoading) {
+    return (
+      <Container
+        size="xl"
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "80vh",
+        }}
+      >
+        <Loader />
+      </Container>
+    );
+  }
+
+  if (isError || !gameInfo || !blueTeam || !redTeam) {
+    return (
+      <Container size="xl" pt="lg">
+        <Center>
+          <Text c="red">
+            데이터 조회 중 에러가 발생했거나 데이터가 없습니다:{" "}
+            {error instanceof Error ? error.message : "알 수 없는 오류"}
+          </Text>
+        </Center>
+      </Container>
+    );
+  }
+
+  const gameLengthInMin = gameInfo.gamelength / 60;
+
+  return (
+    <Container size="xl" px={{ base: 12, sm: 24, md: 32 }}>
+      <Stack gap="lg" mt="md">
+        <GameHeader
+          gameInfo={gameInfo}
+          blueTeam={blueTeam}
+          redTeam={redTeam}
+          getChampionImageUrl={getChampionImageUrl}
+        />
+
+        <Tabs value={activeTab} onChange={setActiveTab} mt="md">
+          <ScrollArea pb="xs" scrollbarSize={4} type="auto">
+            <Tabs.List style={{ flexWrap: "nowrap", minWidth: "max-content" }}>
+              <Tabs.Tab value="overview">경기 개요</Tabs.Tab>
+              <Tabs.Tab value="players">선수 기록</Tabs.Tab>
+              <Tabs.Tab value="objectives">오브젝트</Tabs.Tab>
+              <Tabs.Tab value="timeline">타임라인 분석</Tabs.Tab>
+            </Tabs.List>
+          </ScrollArea>
+
+          <Tabs.Panel value="overview" pt="md">
+            <OverviewTab blueTeam={blueTeam} redTeam={redTeam} />
+          </Tabs.Panel>
+          <Tabs.Panel value="players" pt="md">
+            <PlayersTab
+              blueTeam={blueTeam}
+              redTeam={redTeam}
+              gameLengthInMin={gameLengthInMin}
+              getChampionImageUrl={getChampionImageUrl}
+            />
+          </Tabs.Panel>
+          <Tabs.Panel value="objectives" pt="md">
+            <ObjectivesTab blueTeam={blueTeam} redTeam={redTeam} />
+          </Tabs.Panel>
+          <Tabs.Panel value="timeline" pt="md">
+            {gameData && (
+              <TimelineAnalysisTab
+                gameData={gameData}
+                getChampionImageUrl={getChampionImageUrl}
+              />
+            )}
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+    </Container>
+  );
+}

--- a/src/pages/game-record/ui/objectives-tab.tsx
+++ b/src/pages/game-record/ui/objectives-tab.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { Paper, Stack, Title, Grid, Text, Divider } from "@mantine/core";
+
+interface TeamStats {
+  dragons: number;
+  heralds: number;
+  barons: number;
+  elders: number;
+  voidGrubs: number;
+  infernals: number;
+  mountains: number;
+  clouds: number;
+  oceans: number;
+  chemtechs: number;
+  hextechs: number;
+  towers: number;
+  inhibitors: number;
+  turretPlates: number;
+}
+
+interface TeamData {
+  name: string;
+  stats: TeamStats;
+}
+
+interface ObjectivesTabProps {
+  blueTeam: TeamData;
+  redTeam: TeamData;
+}
+
+interface ObjectiveRowProps {
+  label: string;
+  blue: number;
+  red: number;
+}
+
+function ObjectiveRow({ label, blue, red }: ObjectiveRowProps) {
+  return (
+    <Grid align="center" gutter="xs">
+      <Grid.Col span={5}>
+        <Text
+          ta="right"
+          fw={blue > red ? 700 : 400}
+          c={blue > red ? "dark" : "dimmed"}
+        >
+          {blue}
+        </Text>
+      </Grid.Col>
+      <Grid.Col span={2}>
+        <Text ta="center" c="dimmed" size="sm">
+          {label}
+        </Text>
+      </Grid.Col>
+      <Grid.Col span={5}>
+        <Text
+          ta="left"
+          fw={red > blue ? 700 : 400}
+          c={red > blue ? "dark" : "dimmed"}
+        >
+          {red}
+        </Text>
+      </Grid.Col>
+    </Grid>
+  );
+}
+
+export function ObjectivesTab({ blueTeam, redTeam }: ObjectivesTabProps) {
+  const majorObjectives = [
+    {
+      label: "드래곤",
+      blue: blueTeam.stats.dragons,
+      red: redTeam.stats.dragons,
+    },
+    { label: "전령", blue: blueTeam.stats.heralds, red: redTeam.stats.heralds },
+    { label: "바론", blue: blueTeam.stats.barons, red: redTeam.stats.barons },
+    { label: "장로", blue: blueTeam.stats.elders, red: redTeam.stats.elders },
+    {
+      label: "공허 유충",
+      blue: blueTeam.stats.voidGrubs,
+      red: redTeam.stats.voidGrubs,
+    },
+  ];
+
+  const elementalDrakes = [
+    {
+      label: "화염",
+      blue: blueTeam.stats.infernals,
+      red: redTeam.stats.infernals,
+    },
+    {
+      label: "산악",
+      blue: blueTeam.stats.mountains,
+      red: redTeam.stats.mountains,
+    },
+    { label: "바람", blue: blueTeam.stats.clouds, red: redTeam.stats.clouds },
+    { label: "대양", blue: blueTeam.stats.oceans, red: redTeam.stats.oceans },
+    {
+      label: "화공",
+      blue: blueTeam.stats.chemtechs,
+      red: redTeam.stats.chemtechs,
+    },
+    {
+      label: "마공",
+      blue: blueTeam.stats.hextechs,
+      red: redTeam.stats.hextechs,
+    },
+  ].filter((drake) => drake.blue > 0 || drake.red > 0);
+
+  const structures = [
+    { label: "타워", blue: blueTeam.stats.towers, red: redTeam.stats.towers },
+    {
+      label: "억제기",
+      blue: blueTeam.stats.inhibitors,
+      red: redTeam.stats.inhibitors,
+    },
+    {
+      label: "타워 플레이트",
+      blue: blueTeam.stats.turretPlates,
+      red: redTeam.stats.turretPlates,
+    },
+  ];
+
+  return (
+    <Stack gap="lg" mt="lg">
+      <Paper p="lg" withBorder radius="md">
+        <Title order={3} mb="lg" ta="center">
+          오브젝트 상세
+        </Title>
+
+        <Grid>
+          <Grid.Col span={5}>
+            <Text ta="right" fw={700} c="blue">
+              {blueTeam.name}
+            </Text>
+          </Grid.Col>
+          <Grid.Col span={2}></Grid.Col>
+          <Grid.Col span={5}>
+            <Text ta="left" fw={700} c="red">
+              {redTeam.name}
+            </Text>
+          </Grid.Col>
+        </Grid>
+
+        <Divider my="sm" />
+
+        <Stack gap="sm">
+          <Text size="sm" fw={500} c="dimmed" ta="center">
+            주요 오브젝트
+          </Text>
+          {majorObjectives.map((obj) => (
+            <ObjectiveRow key={obj.label} {...obj} />
+          ))}
+        </Stack>
+
+        <Divider my="md" label="구조물" labelPosition="center" />
+
+        <Stack gap="sm">
+          {structures.map((obj) => (
+            <ObjectiveRow key={obj.label} {...obj} />
+          ))}
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/pages/game-record/ui/overview-tab.tsx
+++ b/src/pages/game-record/ui/overview-tab.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { Stack, Paper, Title } from "@mantine/core";
+import { StatComparisonBar } from "./stat-comparison-bar";
+
+interface TeamStats {
+  kills: number;
+  totalGold: number;
+  totalDamage: number;
+  visionScore: number;
+  dragons: number;
+  barons: number;
+  heralds: number;
+  towers: number;
+  inhibitors: number;
+  voidGrubs: number;
+  firstDragon: boolean;
+  firstBaron: boolean;
+  firstHerald: boolean;
+  firstTower: boolean;
+}
+
+interface TeamData {
+  name: string;
+  stats: TeamStats;
+}
+
+interface OverviewTabProps {
+  blueTeam: TeamData;
+  redTeam: TeamData;
+}
+
+export function OverviewTab({ blueTeam, redTeam }: OverviewTabProps) {
+  if (!blueTeam?.stats || !redTeam?.stats) return null;
+
+  const formatK = (v: number) => `${((v || 0) / 1000).toFixed(1)}K`;
+
+  const teamStats = [
+    { label: "킬", blue: blueTeam.stats.kills, red: redTeam.stats.kills },
+    {
+      label: "골드",
+      blue: blueTeam.stats.totalGold,
+      red: redTeam.stats.totalGold,
+      format: formatK,
+    },
+    {
+      label: "데미지",
+      blue: blueTeam.stats.totalDamage,
+      red: redTeam.stats.totalDamage,
+      format: formatK,
+    },
+    {
+      label: "시야 점수",
+      blue: blueTeam.stats.visionScore,
+      red: redTeam.stats.visionScore,
+    },
+  ];
+
+  const objectiveStats = [
+    {
+      label: "드래곤",
+      blue: blueTeam.stats.dragons,
+      red: redTeam.stats.dragons,
+      first: blueTeam.stats.firstDragon
+        ? "blue"
+        : redTeam.stats.firstDragon
+          ? "red"
+          : null,
+    },
+    {
+      label: "바론",
+      blue: blueTeam.stats.barons,
+      red: redTeam.stats.barons,
+      first: blueTeam.stats.firstBaron
+        ? "blue"
+        : redTeam.stats.firstBaron
+          ? "red"
+          : null,
+    },
+    {
+      label: "전령",
+      blue: blueTeam.stats.heralds,
+      red: redTeam.stats.heralds,
+      first: blueTeam.stats.firstHerald
+        ? "blue"
+        : redTeam.stats.firstHerald
+          ? "red"
+          : null,
+    },
+    {
+      label: "타워",
+      blue: blueTeam.stats.towers,
+      red: redTeam.stats.towers,
+      first: blueTeam.stats.firstTower
+        ? "blue"
+        : redTeam.stats.firstTower
+          ? "red"
+          : null,
+    },
+    {
+      label: "억제기",
+      blue: blueTeam.stats.inhibitors,
+      red: redTeam.stats.inhibitors,
+    },
+    {
+      label: "공허 유충",
+      blue: blueTeam.stats.voidGrubs,
+      red: redTeam.stats.voidGrubs,
+    },
+  ];
+
+  return (
+    <Stack gap="lg" mt="lg">
+      <Paper p={{ base: "md", sm: "lg" }} withBorder radius="sm">
+        <Title order={3} mb="lg" ta="center">
+          팀 스탯 비교
+        </Title>
+        <Stack gap="xl">
+          {teamStats.map((stat) => (
+            <StatComparisonBar
+              key={stat.label}
+              label={stat.label}
+              blueValue={stat.blue}
+              redValue={stat.red}
+              format={stat.format}
+            />
+          ))}
+        </Stack>
+      </Paper>
+
+      <Paper p={{ base: "md", sm: "lg" }} withBorder radius="sm">
+        <Title order={3} mb="lg" ta="center">
+          오브젝트 관리
+        </Title>
+        <Stack gap="xl">
+          {objectiveStats.map((obj) => (
+            <StatComparisonBar
+              key={obj.label}
+              label={obj.label}
+              blueValue={obj.blue}
+              redValue={obj.red}
+              firstObjectiveSide={obj.first as "blue" | "red" | null}
+            />
+          ))}
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/pages/game-record/ui/player-stats-table.tsx
+++ b/src/pages/game-record/ui/player-stats-table.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Table, ScrollArea, Group, Avatar, Stack, Text, Badge } from "@mantine/core";
+import type { GameDetailPlayer } from "@/entities/games/model/games.dto";
+
+interface PlayerStatsTableProps {
+  players: GameDetailPlayer[];
+  teamKills: number;
+  gameLengthInMin: number;
+  getChampionImageUrl: (name: string) => string;
+}
+
+const calculateKP = (kills: number, assists: number, teamKills: number) => {
+  if (teamKills === 0) return "0%";
+  return `${Math.round(((kills + assists) / teamKills) * 100)}%`;
+};
+
+const renderKeyRecords = (player: GameDetailPlayer) => {
+  const records: React.ReactNode[] = [];
+  const badgeProps = { variant: "light" as const, size: "sm" as const, radius: "xs" as const };
+
+  // '퍼블 당함' 기록 (부정적 지표이므로 다른 스타일 적용)
+  if (player.isFirstBloodVictim) {
+    records.push(
+      <Badge key="fbv" color="gray" variant="filled" size="sm" radius="xs">
+        퍼블 당함
+      </Badge>
+    );
+  }
+  // '퍼블' 기록
+  if (player.isFirstBloodKill) {
+    records.push(
+      <Badge key="fbk" color="gray" {...badgeProps}>
+        퍼블
+      </Badge>
+    );
+  }
+  // 멀티킬 기록 (x2, x3 형식으로 변경)
+  if (player.doubleKills > 0) {
+    records.push(
+      <Badge key="double" color="gray" {...badgeProps}>
+        더블킬 x{player.doubleKills}
+      </Badge>
+    );
+  }
+  if (player.tripleKills > 0) {
+    records.push(
+      <Badge key="triple" color="gray" {...badgeProps}>
+        트리플킬 x{player.tripleKills}
+      </Badge>
+    );
+  }
+  if (player.quadraKills > 0) {
+    records.push(
+      <Badge key="quadra" color="gray" {...badgeProps}>
+        쿼드라킬 x{player.quadraKills}
+      </Badge>
+    );
+  }
+  if (player.pentaKills > 0) {
+    records.push(
+      <Badge key="penta" color="gray" {...badgeProps}>
+        펜타킬 x{player.pentaKills}
+      </Badge>
+    );
+  }
+
+  if (records.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        -
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap={4} align="flex-start">
+      {records}
+    </Stack>
+  );
+};
+
+export function PlayerStatsTable({
+  players,
+  teamKills,
+  gameLengthInMin,
+  getChampionImageUrl,
+}: PlayerStatsTableProps) {
+  return (
+    <ScrollArea>
+      <Table striped highlightOnHover miw={700}>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>선수</Table.Th>
+            <Table.Th>KDA</Table.Th>
+            <Table.Th>주요 기록</Table.Th>
+            <Table.Th>데미지(DPM)</Table.Th>
+            <Table.Th>CS(CSPM)</Table.Th>
+            <Table.Th visibleFrom="sm">골드</Table.Th>
+            <Table.Th visibleFrom="sm">시야(VSPM)</Table.Th>
+            <Table.Th visibleFrom="sm">KP</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {players.map((p) => (
+            <Table.Tr key={p.participantid}>
+              <Table.Td>
+                <Group gap="sm">
+                  <Avatar src={getChampionImageUrl(p.champion)} radius="sm" />
+                  <Stack gap={0}>
+                    <Text size="sm" fw={600}>
+                      {p.playername}
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      {p.champion}
+                    </Text>
+                  </Stack>
+                </Group>
+              </Table.Td>
+              <Table.Td>
+                <Text size="sm" fw={600}>
+                  {p.kills}/{p.deaths}/{p.assists}
+                </Text>
+              </Table.Td>
+              <Table.Td>{renderKeyRecords(p)}</Table.Td>
+              <Table.Td>
+                <Stack gap={0}>
+                  <Text size="sm">{(p.damageToChampions / 1000).toFixed(1)}K</Text>
+                  <Text size="xs" c="dimmed">
+                    {p.dpm}
+                  </Text>
+                </Stack>
+              </Table.Td>
+              <Table.Td>
+                <Stack gap={0}>
+                  <Text size="sm">{p.totalCs}</Text>
+                  <Text size="xs" c="dimmed">
+                    {p.cspm.toFixed(1)}
+                  </Text>
+                </Stack>
+              </Table.Td>
+              <Table.Td visibleFrom="sm">
+                <Text size="sm">{(p.totalGold / 1000).toFixed(1)}K</Text>
+              </Table.Td>
+              <Table.Td visibleFrom="sm">
+                <Stack gap={0}>
+                  <Text size="sm">{p.visionScore}</Text>
+                  <Text size="xs" c="dimmed">
+                    {p.vspm.toFixed(1)}
+                  </Text>
+                </Stack>
+              </Table.Td>
+              <Table.Td visibleFrom="sm">
+                <Text size="sm">{calculateKP(p.kills, p.assists, teamKills)}</Text>
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </ScrollArea>
+  );
+}

--- a/src/pages/game-record/ui/players-tab.tsx
+++ b/src/pages/game-record/ui/players-tab.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Stack, Paper, Group, Text, Badge } from "@mantine/core";
+import { PlayerStatsTable } from "./player-stats-table";
+import type { GameDetailPlayer } from "@/entities/games/model/games.dto";
+
+interface TeamData {
+  name: string;
+  result: number;
+  players: GameDetailPlayer[];
+  stats: {
+    kills: number;
+  };
+}
+
+interface PlayersTabProps {
+  blueTeam: TeamData;
+  redTeam: TeamData;
+  gameLengthInMin: number;
+  getChampionImageUrl: (name: string) => string;
+}
+
+export function PlayersTab({
+  blueTeam,
+  redTeam,
+  gameLengthInMin,
+  getChampionImageUrl,
+}: PlayersTabProps) {
+  return (
+    <Stack gap="lg" mt="lg">
+      <Paper p="lg" withBorder radius="sm">
+        <Group mb="md">
+          <Text size="lg" fw={700} c="blue">
+            {blueTeam.name}
+          </Text>
+          {blueTeam.result === 1 && (
+            <Badge color="blue" radius="xs">
+              승리
+            </Badge>
+          )}
+        </Group>
+        <PlayerStatsTable
+          players={blueTeam.players}
+          teamKills={blueTeam.stats.kills}
+          gameLengthInMin={gameLengthInMin}
+          getChampionImageUrl={getChampionImageUrl}
+        />
+      </Paper>
+
+      <Paper p="lg" withBorder radius="sm">
+        <Group mb="md">
+          <Text size="lg" fw={700} c="red">
+            {redTeam.name}
+          </Text>
+          {redTeam.result === 1 && (
+            <Badge color="red" radius="xs">
+              승리
+            </Badge>
+          )}
+        </Group>
+        <PlayerStatsTable
+          players={redTeam.players}
+          teamKills={redTeam.stats.kills}
+          gameLengthInMin={gameLengthInMin}
+          getChampionImageUrl={getChampionImageUrl}
+        />
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/pages/game-record/ui/stat-comparison-bar.tsx
+++ b/src/pages/game-record/ui/stat-comparison-bar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Group, Progress, Text, Badge, Stack } from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+
+interface StatComparisonBarProps {
+  label: string;
+  blueValue: number;
+  redValue: number;
+  format?: (v: number) => string;
+  firstObjectiveSide?: "blue" | "red" | null;
+}
+
+export function StatComparisonBar({
+  label,
+  blueValue,
+  redValue,
+  format,
+  firstObjectiveSide,
+}: StatComparisonBarProps) {
+  const isMobile = useMediaQuery("(max-width: 768px)");
+  const total = (blueValue || 0) + (redValue || 0) || 1;
+  const bluePercentage = ((blueValue || 0) / total) * 100;
+
+  const formattedBlue = format ? format(blueValue) : blueValue ?? 0;
+  const formattedRed = format ? format(redValue) : redValue ?? 0;
+
+  return (
+    <Group
+      align="flex-start"
+      justify="center"
+      wrap="nowrap"
+      gap={isMobile ? "xs" : "md"}
+    >
+      {/* --- 왼쪽(블루팀) 영역 --- */}
+      <Stack gap={4} align="stretch" style={{ flex: 1 }}>
+        <Group
+          wrap="nowrap"
+          gap={isMobile ? 4 : "xs"}
+          style={{ flex: 1, justifyContent: "flex-end" }}
+        >
+          <Text
+            fw={700}
+            size={isMobile ? "sm" : "lg"}
+            c={blueValue > redValue ? "dark" : "dimmed"}
+          >
+            {formattedBlue}
+          </Text>
+          <Progress
+            value={bluePercentage}
+            size="sm"
+            radius="xs"
+            color="blue"
+            bg="gray.2"
+            style={{ flex: 1, transform: "scaleX(-1)", minWidth: 30 }}
+          />
+        </Group>
+        {/* 블루팀이 첫 오브젝트일 경우 배지 표시 */}
+        {firstObjectiveSide === "blue" && (
+          <Group justify="flex-end">
+            <Badge size="xs" variant="light" color="gray" radius="sm">
+              첫 {label}
+            </Badge>
+          </Group>
+        )}
+      </Stack>
+
+      {/* --- 중앙 라벨 --- */}
+      <Text fw={600} size="sm" w={isMobile ? 60 : 80} ta="center" pt={4}>
+        {label}
+      </Text>
+
+      {/* --- 오른쪽(레드팀) 영역 --- */}
+      <Stack gap={4} align="stretch" style={{ flex: 1 }}>
+        <Group wrap="nowrap" gap={isMobile ? 4 : "xs"} style={{ flex: 1 }}>
+          <Progress
+            value={100 - bluePercentage}
+            size="sm"
+            radius="xs"
+            color="red"
+            bg="gray.2"
+            style={{ flex: 1, minWidth: 30 }}
+          />
+          <Text
+            fw={700}
+            size={isMobile ? "sm" : "lg"}
+            c={redValue > blueValue ? "dark" : "dimmed"}
+          >
+            {formattedRed}
+          </Text>
+        </Group>
+        {/* 레드팀이 첫 오브젝트일 경우 배지 표시 */}
+        {firstObjectiveSide === "red" && (
+          <Group justify="flex-start">
+            <Badge size="xs" variant="light" color="gray" radius="sm">
+              첫 {label}
+            </Badge>
+          </Group>
+        )}
+      </Stack>
+    </Group>
+  );
+}

--- a/src/pages/game-record/ui/timeline-analysis-tab.tsx
+++ b/src/pages/game-record/ui/timeline-analysis-tab.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+import React, { useState, useMemo } from "react";
+import {
+  Stack,
+  Paper,
+  Title,
+  Group,
+  Text,
+  Card,
+  SimpleGrid,
+  Table,
+  ScrollArea,
+  Select,
+  Badge,
+  Avatar,
+  Box,
+  SegmentedControl,
+} from "@mantine/core";
+import { LineChart } from "@mantine/charts";
+import type { GameDetailData, GameDetailPlayer } from "@/entities/games/model/games.dto";
+
+const TIME_SELECTOR_DATA = [
+  { label: "10분", value: "10" },
+  { label: "15분", value: "15" },
+  { label: "20분", value: "20" },
+  { label: "25분", value: "25" },
+];
+const POSITIONS = ["전체", "top", "jng", "mid", "bot", "sup"];
+const PLAYER_POSITIONS = ["top", "jng", "mid", "bot", "sup"];
+const METRICS = [
+  { value: "gold", label: "골드" },
+  { value: "xp", label: "경험치" },
+  { value: "cs", label: "CS" },
+  { value: "kills", label: "킬" },
+  { value: "deaths", label: "데스" },
+  { value: "assists", label: "어시스트" },
+];
+const TIME_POINTS = [10, 15, 20, 25];
+
+const createTimelineKey = (metric: string, time: number) => `${metric}At${time}`;
+
+// 플레이어 객체에서 동적 키로 값을 가져오는 헬퍼 함수
+const getPlayerValue = (
+  player: GameDetailPlayer | null | undefined,
+  key: string
+): number => {
+  if (!player) return 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (player as any)[key] ?? 0;
+};
+
+// 플레이어 객체에서 문자열 값을 가져오는 헬퍼 함수
+const getPlayerStringValue = (
+  player: GameDetailPlayer | null | undefined,
+  key: string
+): string => {
+  if (!player) return "";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (player as any)[key] ?? "";
+};
+
+interface ChartTooltipPayload {
+  name: string;
+  value: number;
+  color: string;
+}
+
+interface CustomChartTooltipProps {
+  label?: string | number;
+  payload?: readonly ChartTooltipPayload[];
+  active?: boolean;
+}
+
+function CustomChartTooltip({ label, payload, active }: CustomChartTooltipProps) {
+  if (active && payload?.length) {
+    return (
+      <Paper px="sm" py="xs" withBorder shadow="sm" radius="sm">
+        <Text fw={700} mb={5}>
+          {label}
+        </Text>
+        {payload.map((item) => (
+          <Group key={item.name} gap="xs" justify="space-between">
+            <Group gap="xs" align="center">
+              <Box
+                w={10}
+                h={10}
+                bg={item.color}
+                style={{ borderRadius: "50%" }}
+              />
+              <Text size="sm">{item.name}</Text>
+            </Group>
+            <Text size="sm" fw={500}>
+              {item.value.toLocaleString()}
+            </Text>
+          </Group>
+        ))}
+      </Paper>
+    );
+  }
+  return null;
+}
+
+interface TimelineAnalysisTabProps {
+  gameData: GameDetailData;
+  getChampionImageUrl: (name: string) => string;
+}
+
+export function TimelineAnalysisTab({
+  gameData,
+  getChampionImageUrl,
+}: TimelineAnalysisTabProps) {
+  const [selectedPosition, setSelectedPosition] = useState("전체");
+  const [selectedMetric, setSelectedMetric] = useState("gold");
+  const [selectedTime, setSelectedTime] = useState("25");
+
+  const processedData = useMemo(() => {
+    if (!gameData?.players?.length) return null;
+
+    const teamNameMap: Record<string, string> = {
+      "Bnk Fearx": "BFX",
+      "Dplus Kia": "DK",
+      "Kt Rolster": "KT",
+      "Nongshim Redforce": "NS",
+      "Hanwha Life Esports": "HLE",
+      "Gen.g": "GEN",
+      T1: "T1",
+      "Oksavingsbank Brion": "BRO",
+      Drx: "DRX",
+      "Dn Freecs": "DNF",
+    };
+
+    const bluePlayers = gameData.players.filter(
+      (p) => p.side.toLowerCase() === "blue"
+    );
+    const redPlayers = gameData.players.filter(
+      (p) => p.side.toLowerCase() === "red"
+    );
+    if (bluePlayers.length === 0 || redPlayers.length === 0) return null;
+
+    const blueTeamFullName = bluePlayers[0]?.teamname || "Blue Team";
+    const redTeamFullName = redPlayers[0]?.teamname || "Red Team";
+
+    const calculateTeamTotals = (players: GameDetailPlayer[]) => {
+      const totals: Record<number, Record<string, number>> = {};
+      TIME_POINTS.forEach((time) => {
+        totals[time] = {};
+        METRICS.forEach((metricInfo) => {
+          const key = createTimelineKey(metricInfo.value, time);
+          totals[time][metricInfo.value] = players.reduce(
+            (sum, p) => sum + getPlayerValue(p, key),
+            0
+          );
+        });
+      });
+      return totals;
+    };
+
+    return {
+      blueTeam: {
+        name: teamNameMap[blueTeamFullName] || blueTeamFullName,
+        players: bluePlayers,
+        totalsByTime: calculateTeamTotals(bluePlayers),
+      },
+      redTeam: {
+        name: teamNameMap[redTeamFullName] || redTeamFullName,
+        players: redPlayers,
+        totalsByTime: calculateTeamTotals(redPlayers),
+      },
+    };
+  }, [gameData]);
+
+  const chartData = useMemo(() => {
+    if (!processedData) return [];
+    const isTotalView = selectedPosition === "전체";
+    const bluePlayer = isTotalView
+      ? null
+      : processedData.blueTeam.players.find(
+          (p) => p.position === selectedPosition
+        );
+    const redPlayer = isTotalView
+      ? null
+      : processedData.redTeam.players.find(
+          (p) => p.position === selectedPosition
+        );
+    return TIME_POINTS.map((time) => {
+      const key = createTimelineKey(selectedMetric, time);
+      const blueValue = isTotalView
+        ? processedData.blueTeam.totalsByTime[time][selectedMetric]
+        : getPlayerValue(bluePlayer, key);
+      const redValue = isTotalView
+        ? processedData.redTeam.totalsByTime[time][selectedMetric]
+        : getPlayerValue(redPlayer, key);
+      return {
+        time: `${time}분`,
+        [processedData.blueTeam.name]: blueValue,
+        [processedData.redTeam.name]: redValue,
+      };
+    });
+  }, [processedData, selectedPosition, selectedMetric]);
+
+  if (!processedData) {
+    return (
+      <Paper p="lg" withBorder mt="lg" radius="sm">
+        <Text ta="center" c="dimmed">
+          타임라인 데이터를 표시할 수 없습니다.
+        </Text>
+      </Paper>
+    );
+  }
+
+  const { blueTeam, redTeam } = processedData;
+  const isTotalView = selectedPosition === "전체";
+
+  const getDifference = (time: number) => {
+    const key = createTimelineKey(selectedMetric, time);
+    if (isTotalView) {
+      return (
+        blueTeam.totalsByTime[time][selectedMetric] -
+        redTeam.totalsByTime[time][selectedMetric]
+      );
+    }
+    const bluePlayer = blueTeam.players.find(
+      (p) => p.position === selectedPosition
+    );
+    const redPlayer = redTeam.players.find(
+      (p) => p.position === selectedPosition
+    );
+    return getPlayerValue(bluePlayer, key) - getPlayerValue(redPlayer, key);
+  };
+
+  const positionDisplayText = isTotalView
+    ? "팀 전체"
+    : selectedPosition.toUpperCase();
+  const metricLabel =
+    METRICS.find((m) => m.value === selectedMetric)?.label || "";
+
+  return (
+    <Stack gap="lg" mt="lg">
+      {/* 필터 */}
+      <Paper p="md" withBorder radius="sm">
+        <Group gap="md" wrap="wrap">
+          <Select
+            label="포지션"
+            value={selectedPosition}
+            onChange={(v) => setSelectedPosition(v || "전체")}
+            data={POSITIONS}
+            style={{ minWidth: 120 }}
+          />
+          <Select
+            label="지표"
+            value={selectedMetric}
+            onChange={(v) => setSelectedMetric(v || "gold")}
+            data={METRICS.slice(0, 4)}
+            style={{ minWidth: 120 }}
+          />
+        </Group>
+      </Paper>
+
+      {/* 시간대별 차트 */}
+      <Paper p="lg" withBorder radius="sm">
+        <Title order={3}>
+          {positionDisplayText} {metricLabel} 추이
+        </Title>
+        <LineChart
+          h={300}
+          data={chartData}
+          dataKey="time"
+          series={[
+            { name: blueTeam.name, color: "blue.6" },
+            { name: redTeam.name, color: "red.6" },
+          ]}
+          curveType="linear"
+          withLegend={false}
+          tooltipProps={{ content: CustomChartTooltip }}
+        />
+        <Group justify="center" mt="md" gap="lg">
+          <Group gap="xs">
+            <Box w={12} h={3} bg="blue.6" />
+            <Text size="sm">{blueTeam.name}</Text>
+          </Group>
+          <Group gap="xs">
+            <Box w={12} h={3} bg="red.6" />
+            <Text size="sm">{redTeam.name}</Text>
+          </Group>
+        </Group>
+      </Paper>
+
+      {/* 차이 분석 카드 */}
+      <Paper p="lg" withBorder radius="sm">
+        <Title order={3} mb="md">
+          {positionDisplayText} 시간대별 {metricLabel} 격차
+        </Title>
+        <SimpleGrid cols={{ base: 2, md: 4 }} spacing="md">
+          {TIME_POINTS.map((time) => {
+            const diff = getDifference(time);
+            const isBlueAhead = diff >= 0;
+            const leadTeam = isBlueAhead ? blueTeam : redTeam;
+            const leadColor = isBlueAhead ? "blue" : "red";
+            return (
+              <Card key={time} p="md" withBorder radius="sm">
+                <Stack align="center" gap="xs">
+                  <Text size="sm" fw={600}>
+                    {time}분
+                  </Text>
+                  <Badge variant="light" color={leadColor} size="lg" radius="sm">
+                    {leadTeam.name} 우세
+                  </Badge>
+                  <Text size="lg" fw={700} c={leadColor}>
+                    +{Math.abs(diff).toLocaleString()}
+                  </Text>
+                </Stack>
+              </Card>
+            );
+          })}
+        </SimpleGrid>
+      </Paper>
+
+      {/* 상세 지표 테이블 */}
+      <Paper p="lg" withBorder radius="sm">
+        <Title order={3} mb="md">
+          팀 전체 상세 지표
+        </Title>
+        <ScrollArea>
+          <Table
+            striped
+            highlightOnHover
+            withTableBorder
+            withColumnBorders
+            miw={800}
+          >
+            <Table.Thead>
+              <Table.Tr>
+                {["시간", "팀", ...METRICS.map((m) => m.label)].map((h) => (
+                  <Table.Th key={h}>{h}</Table.Th>
+                ))}
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {TIME_POINTS.map((time) => (
+                <React.Fragment key={time}>
+                  <Table.Tr>
+                    <Table.Td rowSpan={2}>
+                      <Text fw={600}>{time}분</Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge color="blue" variant="light" radius="sm">
+                        {blueTeam.name}
+                      </Badge>
+                    </Table.Td>
+                    {METRICS.map((m) => (
+                      <Table.Td key={`${time}-blue-${m.value}`}>
+                        {blueTeam.totalsByTime[time][m.value].toLocaleString()}
+                      </Table.Td>
+                    ))}
+                  </Table.Tr>
+                  <Table.Tr>
+                    <Table.Td>
+                      <Badge color="red" variant="light" radius="sm">
+                        {redTeam.name}
+                      </Badge>
+                    </Table.Td>
+                    {METRICS.map((m) => (
+                      <Table.Td key={`${time}-red-${m.value}`}>
+                        {redTeam.totalsByTime[time][m.value].toLocaleString()}
+                      </Table.Td>
+                    ))}
+                  </Table.Tr>
+                </React.Fragment>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </ScrollArea>
+      </Paper>
+
+      {/* 포지션별 지표 비교 테이블 */}
+      <Paper p="lg" withBorder radius="sm">
+        <Stack gap="md">
+          <Title order={3}>
+            {selectedTime}분 포지션별 지표 비교
+          </Title>
+          <SegmentedControl
+            value={selectedTime}
+            onChange={setSelectedTime}
+            data={TIME_SELECTOR_DATA}
+            color="blue"
+            fullWidth
+          />
+        </Stack>
+        <ScrollArea mt="md">
+          <Table
+            striped
+            highlightOnHover
+            withTableBorder
+            withColumnBorders
+            miw={700}
+          >
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>포지션</Table.Th>
+                <Table.Th>선수</Table.Th>
+                <Table.Th>골드 (격차)</Table.Th>
+                <Table.Th>CS (격차)</Table.Th>
+                <Table.Th>K/D/A</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {PLAYER_POSITIONS.map((pos) => {
+                const blueP = blueTeam.players.find(
+                  (p) => p.position.toLowerCase() === pos
+                );
+                const redP = redTeam.players.find(
+                  (p) => p.position.toLowerCase() === pos
+                );
+
+                const goldDiff = getPlayerValue(blueP, `goldDiffAt${selectedTime}`);
+                const csDiff = getPlayerValue(blueP, `csdiffAt${selectedTime}`);
+
+                return (
+                  <React.Fragment key={pos}>
+                    <Table.Tr>
+                      <Table.Td rowSpan={2}>
+                        <Text fw={600} tt="uppercase">
+                          {pos}
+                        </Text>
+                      </Table.Td>
+                      <Table.Td>
+                        <Group gap="xs" wrap="nowrap">
+                          {getPlayerStringValue(blueP, "champion") && (
+                            <Avatar
+                              src={getChampionImageUrl(getPlayerStringValue(blueP, "champion"))}
+                              size={24}
+                              radius="sm"
+                            />
+                          )}
+                          <Text size="sm">
+                            {getPlayerStringValue(blueP, "playername") || "N/A"}
+                          </Text>
+                        </Group>
+                      </Table.Td>
+                      <Table.Td>
+                        <Group gap={4} wrap="nowrap">
+                          <Text size="sm">
+                            {getPlayerValue(blueP, createTimelineKey("gold", parseInt(selectedTime))).toLocaleString()}
+                          </Text>
+                          <Text
+                            c={goldDiff >= 0 ? "blue" : "red"}
+                            size="xs"
+                          >
+                            ({goldDiff >= 0 ? "+" : ""}
+                            {goldDiff})
+                          </Text>
+                        </Group>
+                      </Table.Td>
+                      <Table.Td>
+                        <Group gap={4} wrap="nowrap">
+                          <Text size="sm">
+                            {getPlayerValue(blueP, createTimelineKey("cs", parseInt(selectedTime)))}
+                          </Text>
+                          <Text
+                            c={csDiff >= 0 ? "blue" : "red"}
+                            size="xs"
+                          >
+                            ({csDiff >= 0 ? "+" : ""}
+                            {csDiff})
+                          </Text>
+                        </Group>
+                      </Table.Td>
+                      <Table.Td>
+                        {getPlayerValue(blueP, createTimelineKey("kills", parseInt(selectedTime)))}/
+                        {getPlayerValue(blueP, createTimelineKey("deaths", parseInt(selectedTime)))}/
+                        {getPlayerValue(blueP, createTimelineKey("assists", parseInt(selectedTime)))}
+                      </Table.Td>
+                    </Table.Tr>
+                    <Table.Tr>
+                      <Table.Td>
+                        <Group gap="xs" wrap="nowrap">
+                          {getPlayerStringValue(redP, "champion") && (
+                            <Avatar
+                              src={getChampionImageUrl(getPlayerStringValue(redP, "champion"))}
+                              size={24}
+                              radius="sm"
+                            />
+                          )}
+                          <Text size="sm">
+                            {getPlayerStringValue(redP, "playername") || "N/A"}
+                          </Text>
+                        </Group>
+                      </Table.Td>
+                      <Table.Td>
+                        <Group gap={4} wrap="nowrap">
+                          <Text size="sm">
+                            {getPlayerValue(redP, createTimelineKey("gold", parseInt(selectedTime))).toLocaleString()}
+                          </Text>
+                          <Text
+                            c={goldDiff <= 0 ? "blue" : "red"}
+                            size="xs"
+                          >
+                            ({goldDiff <= 0 ? "+" : ""}
+                            {-goldDiff})
+                          </Text>
+                        </Group>
+                      </Table.Td>
+                      <Table.Td>
+                        <Group gap={4} wrap="nowrap">
+                          <Text size="sm">
+                            {getPlayerValue(redP, createTimelineKey("cs", parseInt(selectedTime)))}
+                          </Text>
+                          <Text
+                            c={csDiff <= 0 ? "blue" : "red"}
+                            size="xs"
+                          >
+                            ({csDiff <= 0 ? "+" : ""}
+                            {-csDiff})
+                          </Text>
+                        </Group>
+                      </Table.Td>
+                      <Table.Td>
+                        {getPlayerValue(redP, createTimelineKey("kills", parseInt(selectedTime)))}/
+                        {getPlayerValue(redP, createTimelineKey("deaths", parseInt(selectedTime)))}/
+                        {getPlayerValue(redP, createTimelineKey("assists", parseInt(selectedTime)))}
+                      </Table.Td>
+                    </Table.Tr>
+                  </React.Fragment>
+                );
+              })}
+            </Table.Tbody>
+          </Table>
+        </ScrollArea>
+      </Paper>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
프로 경기 상세 기록 페이지(GameRecordPage) 구현

## Changes
- `/pro-matches/[gameId]/record` 라우트 페이지 추가
- `src/pages/game-record/ FSD` 구조로 컴포넌트 구성
- `game-record-page.tsx`: 메인 페이지 (탭 구조)
- `game-header.tsx`: 경기 헤더 (팀 정보, 스코어)
- `overview-tab.tsx`: 경기 개요 탭
- `players-tab.tsx`: 선수 기록 탭
- `player-stats-table.tsx`: 선수 스탯 테이블
- `objectives-tab.tsx`: 오브젝트 탭
- `timeline-analysis-tab.tsx`: 타임라인 분석 탭
- `stat-comparison-bar.tsx`: 팀 스탯 비교 바 컴포넌트
- `use-game-data-processor.ts`: 게임 데이터 가공 훅
- `@mantine/charts`, `recharts` 패키지 추가