### PR TITLE
feat: mantine/dates 및 Dayjs 패키지 설치 및 daypicker 연동

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,6 @@
-@import "tailwindcss";
 @import "@mantine/core/styles.css";
+@import "@mantine/dates/styles.css";
+@import "tailwindcss";
 
 :root {
   --background: #ffffff;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/styled": "^11.14.1",
     "@mantine/charts": "^8.3.10",
     "@mantine/core": "^8.3.10",
+    "@mantine/dates": "^8.3.10",
     "@mantine/hooks": "^8.3.10",
     "@tabler/icons-react": "^3.36.0",
     "@tanstack/react-query": "^5.90.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@mantine/core':
         specifier: ^8.3.10
         version: 8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mantine/dates':
+        specifier: ^8.3.10
+        version: 8.3.10(@mantine/core@8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mantine/hooks@8.3.10(react@19.2.3))(dayjs@1.11.19)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@mantine/hooks':
         specifier: ^8.3.10
         version: 8.3.10(react@19.2.3)
@@ -457,6 +460,15 @@ packages:
     resolution: {integrity: sha512-aKQFETN14v6GtM07b/G5yJneMM1yrgf9mNrTah6GVy5DvQM0AeutITT7toHqh5gxxwzdg/DoY+HQsv5zhqnc5g==}
     peerDependencies:
       '@mantine/hooks': 8.3.10
+      react: ^18.x || ^19.x
+      react-dom: ^18.x || ^19.x
+
+  '@mantine/dates@8.3.10':
+    resolution: {integrity: sha512-P1uZ+alYGp7fsmkfd+7Fur4AGrqT0X6BWLiVTomzrbyykA+m4TSwPyQjKfsDc7XRqaqx992br/U65T82zy+qGQ==}
+    peerDependencies:
+      '@mantine/core': 8.3.10
+      '@mantine/hooks': 8.3.10
+      dayjs: '>=1.0.0'
       react: ^18.x || ^19.x
       react-dom: ^18.x || ^19.x
 
@@ -2837,6 +2849,15 @@ snapshots:
       type-fest: 4.41.0
     transitivePeerDependencies:
       - '@types/react'
+
+  '@mantine/dates@8.3.10(@mantine/core@8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mantine/hooks@8.3.10(react@19.2.3))(dayjs@1.11.19)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@mantine/core': 8.3.10(@mantine/hooks@8.3.10(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mantine/hooks': 8.3.10(react@19.2.3)
+      clsx: 2.1.1
+      dayjs: 1.11.19
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@mantine/hooks@8.3.10(react@19.2.3)':
     dependencies:

--- a/src/pages/pro-matches/schedule/ui/index.tsx
+++ b/src/pages/pro-matches/schedule/ui/index.tsx
@@ -18,7 +18,10 @@ import {
   Center,
   Avatar,
   Loader,
+  Popover,
 } from "@mantine/core";
+import { DatePicker } from "@mantine/dates";
+import "dayjs/locale/ko";
 import {
   IconChevronLeft,
   IconChevronRight,
@@ -152,13 +155,24 @@ export const SchedulePageComponent = () => {
               <ActionIcon variant="light" onClick={handlePrevWeek}>
                 <IconChevronLeft size={18} />
               </ActionIcon>
-              <Group gap="xs">
-                <IconCalendar size={16} color="var(--mantine-color-blue-6)" />
-                <Text fw={600}>
-                  {selectedDate.getFullYear()}.
-                  {String(selectedDate.getMonth() + 1).padStart(2, "0")}
-                </Text>
-              </Group>
+              <Popover position="bottom" withArrow shadow="md">
+                <Popover.Target>
+                  <Group gap="xs" style={{ cursor: "pointer" }}>
+                    <IconCalendar size={16} color="var(--mantine-color-blue-6)" />
+                    <Text fw={600}>
+                      {selectedDate.getFullYear()}.
+                      {String(selectedDate.getMonth() + 1).padStart(2, "0")}
+                    </Text>
+                  </Group>
+                </Popover.Target>
+                <Popover.Dropdown>
+                  <DatePicker
+                    value={selectedDate}
+                    onChange={(date) => date && setSelectedDate(new Date(date))}
+                    locale="ko"
+                  />
+                </Popover.Dropdown>
+              </Popover>
               <ActionIcon variant="light" onClick={handleNextWeek}>
                 <IconChevronRight size={18} />
               </ActionIcon>


### PR DESCRIPTION
## Summary
- 프로 경기 일정 페이지에 날짜 선택 DatePicker 기능 추가
- `@mantine/dates` 및 `dayjs` 패키지 설치
- 캘린더 아이콘 클릭 시 DatePicker 팝오버로 날짜 선택 가능

## Changes
- `@mantine/dates`, `dayjs` 패키지 추가
- `globals.css`에 `@mantine/dates/styles.css` import 추가
- 프로 경기 일정 페이지 캘린더 아이콘에 Popover + DatePicker 연동
- 한국어 locale 적용

Closes #6 
